### PR TITLE
Add operationId and several other fields to the gatsby SpecPath node

### DIFF
--- a/sample/plugins/gatsby-source-openapi-aggregate/processors/spec20Processor.js
+++ b/sample/plugins/gatsby-source-openapi-aggregate/processors/spec20Processor.js
@@ -59,11 +59,22 @@ const spec20Processor = (name, spec) => {
         responses.push(r)
       })
 
+      let xfields = {}
+
+      // copy x-* extension properties 
+      for (key in path) {
+        if (key.startsWith('x-')) {
+          // convert snake-case to snake_case
+          snake_case = key.replace(/-/g, "_");
+          xfields[snake_case] = path[key]
+        }
+      }
+      
       paths.push({
         id: `${rootId}.path.${p}.verb.${v}`,
         parent: rootId,
         children: [...pathResponses.map(pr => pr.id)],
-        fields: {
+        fields: Object.assign({
           name: p,
           verb: v,
           summary: path.summary,
@@ -71,7 +82,13 @@ const spec20Processor = (name, spec) => {
           parameters: path.parameters,
           tags: path.tags,
           tag: path.tags ? path.tags.join(',') : null,
-        },
+          operationId: path.operationId,
+          fullPath: spec.basePath + p,
+          consumes: path.consumes,
+          produces: path.produces,
+          schemes: path.schemes,
+          deprecated: path.deprecated,
+        }, xfields)
       })
     })
   })

--- a/sample/src/spec/SpecPaths.js
+++ b/sample/src/spec/SpecPaths.js
@@ -22,11 +22,12 @@ const SpecPath = ({ path }) => {
         <g.Div marginRight="1rem">
           <Verb value={path.verb} />
         </g.Div>
-        <g.P fontWeight="600">{path.name}</g.P>
+        <g.P fontWeight="600">{path.fullPath}</g.P>
         <g.P marginLeft="auto">{path.summary}</g.P>
       </g.Div>
-      {path.parameters && <SpecPathParameters parameters={path.parameters} />}
+      <g.P fontWeight="600">{path.operationId}()</g.P>
       {path.description && <Markdown markdown={path.description} />}
+      {path.parameters && <SpecPathParameters parameters={path.parameters} />}
       <h3>Responses</h3>
       {responses.map(r => (
         <SpecPathResponse

--- a/sample/src/templates/api.js
+++ b/sample/src/templates/api.js
@@ -49,8 +49,10 @@ export const query = graphql`
       childrenOpenApiSpecPath {
         name
         verb
+        operationId
         summary
         description
+        fullPath
         parameters {
           name
           in


### PR DESCRIPTION
Adds operationId, fullPath, consumes, produces, schemes, and deprecated fields on SpecPath.  Fullpath is spec.basePath + path.name. Defining a computed field is easier than giving SpecPath access to spec.basePath

Adds support for custom extension fields following the `x-project-fieldname` naming pattern, as defined in the Swagger 2.0 spec.  Dashes in the names are changed to underscore to keep graphQL happy.  `x-abc-status` in the swagger SpecPath becomes `x_abc_status` in Gatsby graphQL queries

Small UI change to SpecPath to show some of these new fields in the UI.  Each route now shows the full URL path and operationId (function name).  Sans params, for now.